### PR TITLE
Interchanging the step 3 and 4 may resolve the dashboard loading issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ This documentation willl help user to Install the application in user windows ma
     - docker run -d -p 8086:8086 --network COVID19DashboardbNetwork --name influxdb influxdb
 
   ## Step 3
-
-  - Run below commnd to download the Python Script image from DockerHub and run as a container
-    - docker run -d -p 3000:3000 --network COVID19DashboardbNetwork --name=pythonimage sunishsurendrank/pythonimage:v1
-
-  ## Step 4
   - Run below commnd to download the Grafana Docker Image from DockerHub and run as a container
     - docker run -d -p 3000:3000 --network COVID19DashboardbNetwork --name=grafana sunishsurendrank/grafanaimage:v1
+
+  ## Step 4
+
+  - Run below commnd to download the Python Script image from DockerHub and run as a container
+    - docker run -d -p 3001:3001 --network COVID19DashboardbNetwork --name=pythonimage sunishsurendrank/pythonimage:v1
 
   ## Step 5
 


### PR DESCRIPTION
Hi @sunishsurendrank,

I was able to get the dashboard by following the updated steps. Can you please verify from your side also. 
![dash_issue_resolved](https://user-images.githubusercontent.com/65608078/92981234-4bf8ed80-f499-11ea-9bc9-01b1826276c6.png)

Note: Above screenshot is taken after the following the changed steps in the launching the containers in the README.MD file

I have just interchanged the steps 3 and 4 and changed the port of the python script from 3000 to 3001. I guess the Grafana container should be active when the python script is running. I could draw only this explanation from the analysis. Let me know comments. 

As per previous steps, Grafana and python were being run on the same port in the same network named "COVID19DashboardbNetwork" so that why I have changed the port for python script from 3000 to 3001 and it worked for me.